### PR TITLE
docs: fix README drift from actual project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,14 @@ Welcome to my all-in-one Next.js project with app router!
 - 💎 Integrate with [Tailwind CSS](https://tailwindcss.com)
 - 🖼️ Navigate animation with [next-view-transitions](https://github.com/shuding/next-view-transitions)
 - 🧰 Statem management with [Valtio](https://valtio.pmnd.rs/) and [React Query](https://tanstack.com/query/latest/)
-- ✅ Strict Mode for TypeScript and React 18
-- 📏 Linter with [ESLint](https://eslint.org) (default NextJS, NextJS Core Web Vitals, Tailwind CSS
+- ✅ Strict Mode for TypeScript and React 19
+- 📏 Linter with [ESLint](https://eslint.org) (Next.js Core Web Vitals, TypeScript, React)
 - 💖 Code Formatter with [Prettier](https://prettier.io)
 - 🦊 Husky for Git Hooks
-- 🚫 Lint-staged for running linters on Git staged files
 - 🚓 Lint git commit with Commitlint
 - 🧪 E2E Testing with [Playwright](https://playwright.dev/)
 - 💡 Absolute Imports using `@` prefix
-- 🗂 VSCode configuration: Debug, Settings, Tasks and extension for PostCSS, ESLint, Prettier, TypeScript, Jest
+- 🗂 VSCode configuration: Debug, Settings, Tasks and extension for PostCSS, ESLint, Prettier, TypeScript
 - 🤖 SEO metadata with Next generateMetadata
 - ⚙️ [Bundler Analyzer](https://www.npmjs.com/package/@next/bundle-analyzer)
 - 💯 Maximize lighthouse score
@@ -30,7 +29,7 @@ npx create-next-app -e https://github.com/chongruei/nextjs-app-boilerplate
 ```
 
 ## Requirements
- - Node.js >=20.0.0 and pnpm
+ - Node.js >=20.9.0 and pnpm
 
 ## Getting started
 


### PR DESCRIPTION
## Summary

- React 18 → 19, Node.js requirement `>=20.0.0` → `>=20.9.0` (matches `package.json` `engines` after #12)
- Removed the "Lint-staged" and "VSCode Jest extension" bullets — neither is actually installed in this project, so they were misleading
- Fixed a garbled/unclosed ESLint bullet to describe the actual `eslint-config-next` + `typescript-eslint` + `eslint-plugin-react` flat config setup

No functional changes — docs only.

## Test plan

- [x] `pnpm lint` passes (unaffected, docs-only change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrCyK6YLGQgk9AH3rAMzBf)_