### PR TITLE
ci: add lint and build checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  lint-and-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 9.10.0
+    - name: Use Node.js 20
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'pnpm'
+    - name: Install dependencies
+      run: pnpm install
+    - name: Lint
+      run: pnpm lint
+    - name: Build
+      run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
       uses: pnpm/action-setup@v4
       with:
         version: 9.10.0
-    - name: Use Node.js 20
+    - name: Use Node.js 24
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 24
         cache: 'pnpm'
     - name: Install dependencies
       run: pnpm install


### PR DESCRIPTION
## Summary

- The existing `playwright.yml` workflow only runs e2e tests. Since Next.js 16 removed `next lint` and `next build` no longer lints automatically, there was no CI gate catching lint errors or type errors before merge.
- Adds `.github/workflows/ci.yml` running `pnpm lint` and `pnpm build` on push/PR to `main`/`master`.
- Runs on Node.js 24 to match the `engines.node` floor being introduced in #18 (Node 20 is EOL as of April 2026).

## Test plan

- [x] `pnpm lint` passes locally
- [x] `pnpm build` passes locally
- [ ] New `CI` workflow run on this PR (GitHub Actions)
