### PR TITLE
docs: add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# GENERATE_SOURCEMAP=false
+NEXT_PUBLIC_VERSION=$npm_package_version
+NEXT_PUBLIC_ENV=production
+NEXT_PUBLIC_ENV_NAME=local

--- a/README.md
+++ b/README.md
@@ -42,13 +42,10 @@ pnpm install
 
 ## Local Configuration
 
-Before starting the development server, make sure to add the local configuration file `.env.local` with the following content:
+Before starting the development server, copy `.env.example` to `.env.local`:
 
-```plaintext
-# GENERATE_SOURCEMAP=false
-NEXT_PUBLIC_VERSION=$npm_package_version
-NEXT_PUBLIC_ENV=production
-NEXT_PUBLIC_ENV_NAME=local
+```bash
+cp .env.example .env.local
 ```
 
 ## Start Development Server


### PR DESCRIPTION
## Summary

- New contributors previously had to hand-copy the `.env.local` contents out of the README. Add `.env.example` mirroring the existing `.env.dev`/`.env.stage` shape (no secrets, just env-name placeholders).
- Point the README's "Local Configuration" section at `cp .env.example .env.local` instead of a copy-pasted code block.

## Test plan

- [x] Confirmed `.env.example` is not caught by `.gitignore`'s `.env*.local` pattern
- [x] Docs-only change, no code impact


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrCyK6YLGQgk9AH3rAMzBf)_