### PR TITLE
build(docker): bump Dockerfile base image to node:24-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.19-alpine AS deps
+FROM node:24-alpine AS deps
 RUN apk add --no-cache libc6-compat
 RUN npm install -g pnpm
 WORKDIR /home/node/app
@@ -6,7 +6,7 @@ COPY pnpm-lock.yaml .npmr[c] ./
 
 RUN pnpm fetch
 
-FROM node:20.19-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /home/node/app
 COPY --from=deps /home/node/app/node_modules ./node_modules
 COPY . .
@@ -16,7 +16,7 @@ RUN pnpm install
 
 RUN pnpm build
 
-FROM node:20.19-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /home/node/app
 
 COPY --from=builder /home/node/app/next.config.js ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS deps
+FROM node:20.19-alpine AS deps
 RUN apk add --no-cache libc6-compat
 RUN npm install -g pnpm
 WORKDIR /home/node/app
@@ -6,7 +6,7 @@ COPY pnpm-lock.yaml .npmr[c] ./
 
 RUN pnpm fetch
 
-FROM node:20-alpine AS builder
+FROM node:20.19-alpine AS builder
 WORKDIR /home/node/app
 COPY --from=deps /home/node/app/node_modules ./node_modules
 COPY . .
@@ -16,7 +16,7 @@ RUN pnpm install
 
 RUN pnpm build
 
-FROM node:20-alpine AS runner
+FROM node:20.19-alpine AS runner
 WORKDIR /home/node/app
 
 COPY --from=builder /home/node/app/next.config.js ./


### PR DESCRIPTION
## Summary

- The floating `node:20-alpine` tag was pinned to `node:20.19-alpine` initially, but Node 20 is EOL as of April 2026 — see #18 for the full rationale on why this repo is moving its Node floor to 24.
- Updated instead to `node:24-alpine` (current Active LTS, supported through April 2028), pinning **major only** — this matches Vercel's own stated approach for this repo's production deployment ("pin the major, auto-roll minor/patch updates for security fixes") rather than maintenance-heavy exact-version pinning.
- Applied across all three build stages (`deps`, `builder`, `runner`).

Companion PR: #18 (package.json engines + Playwright CI workflow), #15 (new ci.yml workflow) — all three now agree on Node 24.

## Test plan

- [ ] Could not run `docker build` locally — no Docker daemon available in this sandbox environment. `node:24-alpine` is a standard published tag on the official Node Docker image, so this should pull cleanly in any normal environment; please verify with a local `docker build` before merging if possible.
