### PR TITLE
build: upgrade minimum supported Node.js to 24 (LTS)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [24]
     steps:
     - uses: actions/checkout@v4
     - name: Install pnpm

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prettier-plugin-tailwindcss": "^0.8.0"
   },
   "engines": {
-    "node": ">=20.9.0",
+    "node": ">=24.0.0",
     "pnpm": ">=9.10.0"
   },
   "packageManager": "pnpm@9.10.0"


### PR DESCRIPTION
## Summary

- Node.js 20 reached end-of-life in April 2026.
- Per [Vercel's Node.js version docs](https://vercel.com/docs/functions/runtimes/node-js/node-js-versions), a broad `engines.node` range like our previous `>=20.9.0` already resolves to the latest LTS (currently Node 24) at deploy time — so this repo's actual Vercel production deployment has quietly been on Node 24 already, while local dev, CI, and Docker were still declared as Node 20.
- Bumps `package.json`'s `engines.node` floor to `>=24.0.0` (Active LTS through April 2028) and `.github/workflows/playwright.yml`'s `node-version` matrix to match, so every environment agrees.
- Companion changes to keep the Dockerfile (#17) and the new `ci.yml` workflow (#15) in sync are pushed to those PRs' branches.

## Test plan

- [x] `pnpm install` / `pnpm lint` / `pnpm build` pass locally (this sandbox runs Node 22, which only produces a non-fatal engine-mismatch warning since `engine-strict` isn't set — real CI will run on Node 24)
- [ ] Playwright CI workflow run on Node 24 (this PR's own GitHub Actions run)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrCyK6YLGQgk9AH3rAMzBf)_