### PR TITLE
fix: correct three functional bugs (env config, infinite pagination, nav double-slash)

### DIFF
--- a/e2e/page/config.spec.ts
+++ b/e2e/page/config.spec.ts
@@ -13,8 +13,11 @@ test.describe('Config Page', () => {
       'This is a environment variables page.'
     )
 
+    // ENV_NAME and MOCK are injected via the webServer env in
+    // playwright.config.ts. Before the env.ts fix these read the wrong
+    // (unprefixed) process.env keys and always came back "" / "false".
     await expect(page.getByTestId('env-json-values')).toHaveText(
-      '{ "VERSION": "1.12.0", "MOCK": "false", "ENV_NAME": "", "ANALYZE": "false" }'
+      '{ "VERSION": "1.12.0", "MOCK": "true", "ENV_NAME": "local", "ANALYZE": "false" }'
     )
   })
 })

--- a/e2e/page/navigation.spec.ts
+++ b/e2e/page/navigation.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('http://localhost:3000/en')
+})
+
+test.describe('Navigation links', () => {
+  test('render clean locale-prefixed hrefs without double slashes', async ({ page }) => {
+    const hrefs = await page
+      .locator('nav a')
+      .evaluateAll(links => links.map(a => a.getAttribute('href')))
+
+    expect(hrefs.length).toBeGreaterThan(0)
+
+    // Regression: hrefs used to be built as `/en//about` (double slash),
+    // which Next.js served via an extra 308 redirect on every click.
+    for (const href of hrefs) {
+      expect(href).toBeTruthy()
+      expect(href!.includes('//')).toBe(false)
+    }
+
+    expect(hrefs).toEqual(expect.arrayContaining(['/en', '/en/about', '/en/config', '/en/query']))
+  })
+
+  test('clicking a nav link lands directly on the target URL', async ({ page }) => {
+    await page.locator('nav a[href="/en/about"]').click()
+    await expect(page).toHaveURL('http://localhost:3000/en/about')
+  })
+})

--- a/e2e/page/navigation.spec.ts
+++ b/e2e/page/navigation.spec.ts
@@ -26,4 +26,11 @@ test.describe('Navigation links', () => {
     await page.locator('nav a[href="/en/about"]').click()
     await expect(page).toHaveURL('http://localhost:3000/en/about')
   })
+
+  test('marks exactly the current page as active via aria-current', async ({ page }) => {
+    const activeLinks = page.locator('nav a[aria-current="page"]')
+
+    await expect(activeLinks).toHaveCount(1)
+    await expect(activeLinks).toHaveAttribute('href', '/en')
+  })
 })

--- a/e2e/page/query.spec.ts
+++ b/e2e/page/query.spec.ts
@@ -23,4 +23,23 @@ test.describe('Query Page', () => {
     // Check if there are exactly 10 posts displayed
     expect(posts.length).toBe(10)
   })
+
+  test('stops paginating once a page returns no more posts', async ({ page }) => {
+    // Make the second page come back empty. With the getNextPageParam fix,
+    // an empty page ends pagination and the "Load More" button disappears;
+    // the old code returned pages.length + 1 unconditionally and kept it.
+    await page.route(
+      url => url.pathname === '/posts' && url.searchParams.get('_page') === '2',
+      route => route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+    )
+
+    await page.goto('http://localhost:3000/query')
+
+    const loadMore = page.getByRole('button', { name: 'Load More' })
+    await expect(loadMore).toBeVisible()
+
+    await loadMore.click()
+
+    await expect(loadMore).toHaveCount(0)
+  })
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -73,7 +73,10 @@ export default defineConfig({
     command: 'pnpm build && pnpm start',
     url: 'http://localhost:3000',
     timeout: 120000,
-    reuseExistingServer: !process.env.CI,
+    // Always start a fresh server: an already-running local instance
+    // wouldn't have the env vars below, so config.spec.ts could read
+    // stale values from a leftover process instead of the real ones.
+    reuseExistingServer: false,
     // Exercise the public env vars end-to-end so the /config page has
     // real values to assert against (see config.spec.ts).
     env: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -73,6 +73,12 @@ export default defineConfig({
     command: 'pnpm build && pnpm start',
     url: 'http://localhost:3000',
     timeout: 120000,
-    reuseExistingServer: !process.env.CI
+    reuseExistingServer: !process.env.CI,
+    // Exercise the public env vars end-to-end so the /config page has
+    // real values to assert against (see config.spec.ts).
+    env: {
+      NEXT_PUBLIC_ENV_NAME: 'local',
+      NEXT_PUBLIC_MOCK: 'true'
+    }
   }
 })

--- a/src/components/navigationLink.tsx
+++ b/src/components/navigationLink.tsx
@@ -16,7 +16,7 @@ export default function NavigationLink({ href, ...rest }: ComponentProps<typeof 
   return (
     <TransitionLink
       aria-current={isActive}
-      href={`/${locale}/${href}`}
+      href={href === '/' ? `/${locale}` : `/${locale}${href}`}
       className={clsx(
         'inline-block px-2 py-3 transition-colors',
         isActive ? 'text-white' : 'text-gray-400 hover:text-gray-200'

--- a/src/components/navigationLink.tsx
+++ b/src/components/navigationLink.tsx
@@ -15,7 +15,7 @@ export default function NavigationLink({ href, ...rest }: ComponentProps<typeof 
 
   return (
     <TransitionLink
-      aria-current={isActive}
+      aria-current={isActive ? 'page' : undefined}
       href={href === '/' ? `/${locale}` : `/${locale}${href}`}
       className={clsx(
         'inline-block px-2 py-3 transition-colors',

--- a/src/components/posts/posts.tsx
+++ b/src/components/posts/posts.tsx
@@ -20,7 +20,10 @@ export const Posts = () => {
 
   if (isPending) return <div>Loading...</div>
 
-  if (isError) return <div>Something went wrong.</div>
+  // Only take over the whole view when the initial load failed. A later
+  // fetchNextPage error keeps `data` populated, so keep showing the loaded
+  // posts (and the Load More retry) instead of wiping them.
+  if (isError && !data) return <div>Something went wrong.</div>
 
   return (
     <div className="divide-y" data-testid="post-container">

--- a/src/components/posts/posts.tsx
+++ b/src/components/posts/posts.tsx
@@ -10,14 +10,17 @@ import { getPosts } from '@/services/postServices'
 import { Post } from './post'
 
 export const Posts = () => {
-  const { data, isFetchingNextPage, fetchNextPage, hasNextPage } = useInfiniteQuery<PostType[]>({
-    queryKey: ['posts'],
-    queryFn: ({ pageParam = 1 }) => getPosts({ pageParam: pageParam as number }),
-    initialPageParam: 1,
-    getNextPageParam: (_, pages) => pages.length + 1
-  })
+  const { data, isPending, isError, isFetchingNextPage, fetchNextPage, hasNextPage } =
+    useInfiniteQuery<PostType[]>({
+      queryKey: ['posts'],
+      queryFn: ({ pageParam = 1 }) => getPosts({ pageParam: pageParam as number }),
+      initialPageParam: 1,
+      getNextPageParam: (lastPage, pages) => (lastPage.length > 0 ? pages.length + 1 : undefined)
+    })
 
-  if (!data) return <div>Not found</div>
+  if (isPending) return <div>Loading...</div>
+
+  if (isError) return <div>Something went wrong.</div>
 
   return (
     <div className="divide-y" data-testid="post-container">

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,8 +1,8 @@
 export const env = {
   VERSION: process.env.version || '',
-  MOCK: process.env.MOCK || 'false',
-  ENV_NAME: process.env.ENV_NAME || '',
-  ANALYZE: process.env.NEXT_PUBLIC_ANALYZE || 'false'
+  MOCK: process.env.NEXT_PUBLIC_MOCK || 'false',
+  ENV_NAME: process.env.NEXT_PUBLIC_ENV_NAME || '',
+  ANALYZE: process.env.ANALYZE || 'false'
 }
 
 export const isLocal = env.ENV_NAME === 'local'


### PR DESCRIPTION
## Summary

Three pre-existing functional bugs found during a code review of `src/`:

### 1. `config/env.ts` — env var names never matched what's defined
- Read `process.env.ENV_NAME`, but the `.env.*` files define `NEXT_PUBLIC_ENV_NAME`. Without the `NEXT_PUBLIC_` prefix the value is never exposed to the client, so `env.ENV_NAME` was permanently `''` — which meant `isLocal`/`isDev`/`isStage` were always `false` and `isDevMode` always `true`. The `/config` page displayed an empty `ENV_NAME` regardless of environment.
- Same class of mismatch for `MOCK` (never defined; now reads `NEXT_PUBLIC_MOCK`) and `ANALYZE` (read `NEXT_PUBLIC_ANALYZE`, but the actual flag used by `next.config.js` and the `analyze` script is `ANALYZE`).

### 2. `components/posts/posts.tsx` — infinite "Load More" fetching empty pages
- `getNextPageParam: (_, pages) => pages.length + 1` never returned `undefined`, so `hasNextPage` was always `true`. Now returns `undefined` once a page comes back empty.
- Also replaced the `if (!data) return <div>Not found</div>` fallback (which also showed on query errors) with explicit `isPending` / `isError` states.

### 3. `components/navigationLink.tsx` — double-slash nav URLs
- `href={`/${locale}/${href}`}` while `href` already starts with `/`, producing `/en//about` and `/en//`. Next.js served these via an **extra 308 redirect** on every nav click. Now builds `/en/about` (and `/en` for home) directly.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] Verified against the built standalone server: nav `href`s are now `/en`, `/en/about`, `/en/config`, `/en/query` (no double slashes) and all four resolve `200` with no redirect
- [ ] Full 3-browser Playwright CI (this PR's GitHub Actions run) — note the existing `config.spec.ts` asserts `ENV_NAME: ""`, which still holds in CI since no `.env.local` is present there; the fix changes behavior only when the var is actually set


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrCyK6YLGQgk9AH3rAMzBf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved localized navigation with correct locale-prefixed links, including special handling for the root path.
  - Refined infinite pagination behavior on the Query page to stop when additional results are empty.
- **Bug Fixes**
  - Better posts feed initial state: clearer loading and error messages without disrupting already-loaded pages.
  - Active navigation now reliably reflects the current page for accessibility.
- **Tests**
  - Updated E2E checks for locale navigation active-link behavior and added pagination stop coverage.
- **Chores**
  - Standardized app and E2E environment-variable injection and adjusted test server start behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->