### PR TITLE
fix(security): harden Docker image and add security headers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,25 +1,31 @@
 Dockerfile
-
 .dockerignore
+docker-compose.yml
+
 node_modules
+npm-debug.log*
 
-npm - debug.log
-README.md
-
-cypress
-cypress.config.ts
-
-.yml
-.out
 .next
+out
 .git
+.github
 .husky
-.eslintrc
-.prettier.config.js
-.prettierignore
-.commitlint.config.js
-.nextjs-app-router-boilerplate.code-workspace
+.vscode
 
+# env & secrets
+.env
+.env.*
+
+# config / docs not needed in the image
+*.md
+eslint.config.mjs
+prettier.config.js
+.prettierignore
+commitlint.config.js
+*.code-workspace
+
+# tests
 e2e
 test-results
+playwright-report
 playwright.config.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,18 +19,23 @@ RUN pnpm build
 FROM node:24-alpine AS runner
 WORKDIR /home/node/app
 
+ENV NODE_ENV=production
+
 COPY --from=builder /home/node/app/next.config.js ./
 COPY --from=builder /home/node/app/public ./public
 COPY --from=builder /home/node/app/package.json ./package.json
 
-# Automatically leverage output traces to reduce image size 
+# Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 # Some things are not allowed (see https://github.com/vercel/next.js/issues/38119#issuecomment-1172099259)
 COPY --from=builder --chown=node:node /home/node/app/.next/standalone ./
 COPY --from=builder --chown=node:node /home/node/app/.next/static ./.next/static
 
+USER node
+
 EXPOSE 3000
 
-ENV PORT 3000
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
 
 CMD ["node", "server.js"]

--- a/next.config.js
+++ b/next.config.js
@@ -7,12 +7,32 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
   openAnalyzer: false
 })
 
+const securityHeaders = [
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'X-DNS-Prefetch-Control', value: 'on' },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload'
+  }
+]
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  reactStrictMode: true,
   env: {
     version
   },
-  output: 'standalone'
+  output: 'standalone',
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders
+      }
+    ]
+  }
 }
 
 module.exports = withBundleAnalyzer(withNextIntl(nextConfig))


### PR DESCRIPTION
## Summary

### Dockerfile
- The runner stage chowned files to `node:node` but never added `USER node`, so the container ran as **root**. Added `USER node`.
- Set `NODE_ENV=production`, added `HOSTNAME=0.0.0.0` (required for the standalone server to accept external connections inside a container), and fixed the deprecated `ENV PORT 3000` space-form to `ENV PORT=3000`.

### .dockerignore
- The old file **never ignored `.env*`**, so `.env.dev` / `.env.stage` / `.env.example` were baked into the image by `COPY . .`.
- Several entries used wrong filenames (`.yml`, `.prettier.config.js`, `.commitlint.config.js`, a leading-dot `.nextjs-...code-workspace`) and matched nothing. Rewrote to correctly exclude `.env*`, the compose file, CI/editor/config files, docs, and tests.

### next.config.js
- Enabled `reactStrictMode`.
- Added a baseline set of security response headers: `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `X-DNS-Prefetch-Control`, `Strict-Transport-Security`. CSP intentionally omitted (a strict policy needs nonce wiring to avoid breaking Next's inline scripts/styles).

## Test plan

- [x] `pnpm lint` and `pnpm build` pass
- [x] Verified all five security headers are present on responses from the built standalone server
- [ ] No Docker daemon in this sandbox to run `docker build` — please verify the image builds and runs as `node` locally before merging
- [ ] Full 3-browser Playwright CI (this PR's GitHub Actions run)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrCyK6YLGQgk9AH3rAMzBf)_