### PR TITLE
chore: small cleanups (dead file, misnamed component, global-error)

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 export const dynamic = 'force-static'
 
-export default function ConfigPage(props: Props) {
+export default function AboutPage(props: Props) {
   const params = use(props.params)
 
   const { locale } = params

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+// global-error handles errors thrown in the root layout/segment, where
+// no [locale] layout (and therefore no <html>/<body>) is present, so it
+// must render its own document shell.
+import { useEffect } from 'react'
+
+export default function GlobalError({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    // Log the error to an error reporting service
+    console.error(error)
+  }, [error])
+
+  return (
+    <html>
+      <body>
+        <h2>Something went wrong!</h2>
+        <button onClick={() => reset()}>Try again</button>
+      </body>
+    </html>
+  )
+}


### PR DESCRIPTION
## Summary

- **Delete `src/components/post.tsx`** — an empty 0-byte file that nothing imports (the real component is `src/components/posts/post.tsx`).
- **Rename the About page component** from `ConfigPage` to `AboutPage` — copy-paste leftover, no behavioral change.
- **Add `src/app/global-error.tsx`** so errors thrown at the root segment — where no `[locale]` layout provides `<html>`/`<body>` — render a valid document shell instead of malformed HTML.

The `aria-current` a11y fix (item #15 from the review) was folded into #19 instead, since it touches the same `navigationLink.tsx` lines as the nav-URL fix there and would otherwise conflict.

## Test plan

- [x] `pnpm lint` and `pnpm build` pass
- [ ] Full 3-browser Playwright CI (this PR's GitHub Actions run)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrCyK6YLGQgk9AH3rAMzBf)_