### PR TITLE
test: integrate CodeRabbit-generated unit/e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,7 @@ jobs:
       run: pnpm typecheck
     - name: Lint
       run: pnpm lint
+    - name: Unit tests
+      run: pnpm test:unit
     - name: Build
       run: pnpm build

--- a/e2e/page/navigation.spec.ts
+++ b/e2e/page/navigation.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test'
 
-test.beforeEach(async ({ page }) => {
-  await page.goto('http://localhost:3000/en')
-})
-
 test.describe('Navigation links', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:3000/en')
+  })
+
   test('render clean locale-prefixed hrefs without double slashes', async ({ page }) => {
     const hrefs = await page
       .locator('nav a')
@@ -27,10 +27,82 @@ test.describe('Navigation links', () => {
     await expect(page).toHaveURL('http://localhost:3000/en/about')
   })
 
-  test('marks exactly the current page as active via aria-current', async ({ page }) => {
-    const activeLinks = page.locator('nav a[aria-current="page"]')
+  test('prefixes the home link with the locale without a trailing double slash', async ({
+    page
+  }) => {
+    await expect(page.getByRole('link', { name: 'Home', exact: true })).toHaveAttribute(
+      'href',
+      '/en'
+    )
+  })
 
-    await expect(activeLinks).toHaveCount(1)
-    await expect(activeLinks).toHaveAttribute('href', '/en')
+  test('prefixes non-root links with the locale without an extra slash', async ({ page }) => {
+    await expect(page.getByRole('link', { name: 'About', exact: true })).toHaveAttribute(
+      'href',
+      '/en/about'
+    )
+    await expect(page.getByRole('link', { name: 'Config', exact: true })).toHaveAttribute(
+      'href',
+      '/en/config'
+    )
+    await expect(page.getByRole('link', { name: 'Query', exact: true })).toHaveAttribute(
+      'href',
+      '/en/query'
+    )
+  })
+
+  test('prefixes links with a non-default locale correctly', async ({ page }) => {
+    await page.goto('http://localhost:3000/zh-TW')
+
+    await expect(page.getByRole('link', { name: '首頁', exact: true })).toHaveAttribute(
+      'href',
+      '/zh-TW'
+    )
+    await expect(page.getByRole('link', { name: '關於', exact: true })).toHaveAttribute(
+      'href',
+      '/zh-TW/about'
+    )
+  })
+
+  test('marks the link matching the current page with aria-current="page"', async ({ page }) => {
+    await page.goto('http://localhost:3000/en/about')
+
+    await expect(page.getByRole('link', { name: 'About', exact: true })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
+  })
+
+  test('does not set aria-current on links that do not match the current page', async ({
+    page
+  }) => {
+    await page.goto('http://localhost:3000/en/about')
+
+    await expect(page.getByRole('link', { name: 'Home', exact: true })).not.toHaveAttribute(
+      'aria-current'
+    )
+    await expect(page.getByRole('link', { name: 'Config', exact: true })).not.toHaveAttribute(
+      'aria-current'
+    )
+    await expect(page.getByRole('link', { name: 'Query', exact: true })).not.toHaveAttribute(
+      'aria-current'
+    )
+  })
+
+  test('marks the home link as active only when on the home page', async ({ page }) => {
+    await expect(page.getByRole('link', { name: 'Home', exact: true })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
+
+    await page.goto('http://localhost:3000/en/query')
+
+    await expect(page.getByRole('link', { name: 'Home', exact: true })).not.toHaveAttribute(
+      'aria-current'
+    )
+    await expect(page.getByRole('link', { name: 'Query', exact: true })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
   })
 })

--- a/e2e/page/query.spec.ts
+++ b/e2e/page/query.spec.ts
@@ -25,30 +25,6 @@ test.describe('Query Page', () => {
   })
 })
 
-test.describe('Query Page - loading and error states', () => {
-  test('shows a loading indicator while the posts request is pending', async ({ page }) => {
-    await page.route('https://jsonplaceholder.typicode.com/posts**', async route => {
-      await new Promise(resolve => setTimeout(resolve, 1000))
-      await route.continue()
-    })
-
-    await page.goto('http://localhost:3000/query')
-
-    await expect(page.getByText('Loading...')).toBeVisible()
-    await expect(page.getByTestId('post-container')).toBeVisible()
-  })
-
-  test('shows an error message when the posts request fails', async ({ page }) => {
-    await page.route('https://jsonplaceholder.typicode.com/posts**', route =>
-      route.fulfill({ status: 500, contentType: 'application/json', body: '{}' })
-    )
-
-    await page.goto('http://localhost:3000/query')
-
-    await expect(page.getByText('Something went wrong.')).toBeVisible({ timeout: 15000 })
-  })
-})
-
 test.describe('Query Page - pagination', () => {
   test('fetches and appends additional posts when "Load More" is clicked', async ({ page }) => {
     await page.route('https://jsonplaceholder.typicode.com/posts**', async route => {

--- a/e2e/page/query.spec.ts
+++ b/e2e/page/query.spec.ts
@@ -23,23 +23,133 @@ test.describe('Query Page', () => {
     // Check if there are exactly 10 posts displayed
     expect(posts.length).toBe(10)
   })
+})
 
-  test('stops paginating once a page returns no more posts', async ({ page }) => {
-    // Make the second page come back empty. With the getNextPageParam fix,
-    // an empty page ends pagination and the "Load More" button disappears;
-    // the old code returned pages.length + 1 unconditionally and kept it.
-    await page.route(
-      url => url.pathname === '/posts' && url.searchParams.get('_page') === '2',
-      route => route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+test.describe('Query Page - loading and error states', () => {
+  test('shows a loading indicator while the posts request is pending', async ({ page }) => {
+    await page.route('https://jsonplaceholder.typicode.com/posts**', async route => {
+      await new Promise(resolve => setTimeout(resolve, 1000))
+      await route.continue()
+    })
+
+    await page.goto('http://localhost:3000/query')
+
+    await expect(page.getByText('Loading...')).toBeVisible()
+    await expect(page.getByTestId('post-container')).toBeVisible()
+  })
+
+  test('shows an error message when the posts request fails', async ({ page }) => {
+    await page.route('https://jsonplaceholder.typicode.com/posts**', route =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: '{}' })
     )
 
     await page.goto('http://localhost:3000/query')
 
-    const loadMore = page.getByRole('button', { name: 'Load More' })
-    await expect(loadMore).toBeVisible()
+    await expect(page.getByText('Something went wrong.')).toBeVisible({ timeout: 15000 })
+  })
+})
 
-    await loadMore.click()
+test.describe('Query Page - pagination', () => {
+  test('fetches and appends additional posts when "Load More" is clicked', async ({ page }) => {
+    await page.route('https://jsonplaceholder.typicode.com/posts**', async route => {
+      const url = new URL(route.request().url())
+      const pageParam = Number(url.searchParams.get('_page') ?? '1')
 
-    await expect(loadMore).toHaveCount(0)
+      const posts = Array.from({ length: 5 }, (_, i) => ({
+        userId: 1,
+        id: (pageParam - 1) * 5 + i + 1,
+        title: `Page ${pageParam} title ${i + 1}`,
+        body: `Page ${pageParam} body ${i + 1}`
+      }))
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(posts)
+      })
+    })
+
+    await page.goto('http://localhost:3000/query')
+
+    const posts = page.locator('[data-testid="post"]')
+    await expect(posts).toHaveCount(5)
+
+    await page.getByRole('button', { name: 'Load More' }).click()
+
+    await expect(posts).toHaveCount(10)
+    await expect(page.getByText('Page 2 title 1')).toBeVisible()
+  })
+
+  test('shows "Loading more..." while the next page is being fetched', async ({ page }) => {
+    await page.route('https://jsonplaceholder.typicode.com/posts**', async route => {
+      const url = new URL(route.request().url())
+      const pageParam = Number(url.searchParams.get('_page') ?? '1')
+
+      if (pageParam > 1) {
+        await new Promise(resolve => setTimeout(resolve, 1000))
+      }
+
+      const posts = Array.from({ length: 5 }, (_, i) => ({
+        userId: 1,
+        id: (pageParam - 1) * 5 + i + 1,
+        title: `Page ${pageParam} title ${i + 1}`,
+        body: `Page ${pageParam} body ${i + 1}`
+      }))
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(posts)
+      })
+    })
+
+    await page.goto('http://localhost:3000/query')
+
+    await page.getByRole('button', { name: 'Load More' }).click()
+
+    await expect(page.getByText('Loading more...')).toBeVisible()
+    await expect(page.locator('[data-testid="post"]')).toHaveCount(10)
+  })
+
+  test('stops offering "Load More" once the API returns an empty page', async ({ page }) => {
+    // Regression: with the getNextPageParam fix, an empty page ends
+    // pagination and the "Load More" button disappears; the old code
+    // returned pages.length + 1 unconditionally and kept it around forever.
+    await page.route('https://jsonplaceholder.typicode.com/posts**', async route => {
+      const url = new URL(route.request().url())
+      const pageParam = url.searchParams.get('_page')
+
+      if (pageParam === '2') {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+        return
+      }
+
+      const posts = Array.from({ length: 5 }, (_, i) => ({
+        userId: 1,
+        id: i + 1,
+        title: `Mock title ${i + 1}`,
+        body: `Mock body ${i + 1}`
+      }))
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(posts)
+      })
+    })
+
+    await page.goto('http://localhost:3000/query')
+
+    const posts = page.locator('[data-testid="post"]')
+    await expect(posts).toHaveCount(5)
+
+    const loadMoreButton = page.getByRole('button', { name: 'Load More' })
+    await expect(loadMoreButton).toBeVisible()
+
+    await loadMoreButton.click()
+
+    await expect(posts).toHaveCount(5)
+    await expect(loadMoreButton).not.toBeVisible()
+    await expect(page.getByText('Loading more...')).not.toBeVisible()
   })
 })

--- a/e2e/page/query.spec.ts
+++ b/e2e/page/query.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test'
 
-test.beforeEach(async ({ page }) => {
-  await page.goto('http://localhost:3000/query')
-})
-
 test.describe('Query Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:3000/query')
+  })
+
   test('should display the title and description in English', async ({ page }) => {
     const pageTitle = await page.innerText('h1')
     expect(pageTitle).toBe('React Query')

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "analyze": "ANALYZE=true next build",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
-    "test:unit": "node --test src/**/*.test.ts",
+    "test:unit": "node --test \"src/**/*.test.ts\"",
     "prepare": "husky"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "analyze": "ANALYZE=true next build",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
+    "test:unit": "node --test src/**/*.test.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict'
+import { after, before, test } from 'node:test'
+
+/**
+ * env.ts computes its exported `env` object once, at module evaluation time,
+ * from `process.env`. To exercise different combinations of environment
+ * variables per test we re-import the module with a unique query string on
+ * every call, which forces Node's ESM loader to treat it as a brand new
+ * module and re-evaluate it against the current `process.env`.
+ */
+let importCount = 0
+const importEnv = () => import(`./env.ts?cachebust=${importCount++}`)
+
+const ENV_KEYS = [
+  'version',
+  'NEXT_PUBLIC_MOCK',
+  'NEXT_PUBLIC_ENV_NAME',
+  'ANALYZE',
+  'MOCK',
+  'ENV_NAME',
+  'NEXT_PUBLIC_ANALYZE'
+] as const
+
+const originalEnv: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {}
+
+before(() => {
+  for (const key of ENV_KEYS) originalEnv[key] = process.env[key]
+})
+
+after(() => {
+  for (const key of ENV_KEYS) {
+    if (originalEnv[key] === undefined) delete process.env[key]
+    else process.env[key] = originalEnv[key]
+  }
+})
+
+const clearEnvKeys = () => {
+  for (const key of ENV_KEYS) delete process.env[key]
+}
+
+test('env.MOCK falls back to "false" when NEXT_PUBLIC_MOCK is not set', async () => {
+  clearEnvKeys()
+
+  const { env } = await importEnv()
+
+  assert.equal(env.MOCK, 'false')
+})
+
+test('env.MOCK reads its value from NEXT_PUBLIC_MOCK', async () => {
+  clearEnvKeys()
+  process.env.NEXT_PUBLIC_MOCK = 'true'
+
+  const { env } = await importEnv()
+
+  assert.equal(env.MOCK, 'true')
+})
+
+test('env.MOCK ignores the legacy MOCK variable', async () => {
+  clearEnvKeys()
+  process.env.MOCK = 'true'
+
+  const { env } = await importEnv()
+
+  assert.equal(env.MOCK, 'false')
+})
+
+test('env.ENV_NAME falls back to an empty string when NEXT_PUBLIC_ENV_NAME is not set', async () => {
+  clearEnvKeys()
+
+  const { env } = await importEnv()
+
+  assert.equal(env.ENV_NAME, '')
+})
+
+test('env.ENV_NAME reads its value from NEXT_PUBLIC_ENV_NAME', async () => {
+  clearEnvKeys()
+  process.env.NEXT_PUBLIC_ENV_NAME = 'stage'
+
+  const { env } = await importEnv()
+
+  assert.equal(env.ENV_NAME, 'stage')
+})
+
+test('env.ENV_NAME ignores the legacy ENV_NAME variable', async () => {
+  clearEnvKeys()
+  process.env.ENV_NAME = 'prod'
+
+  const { env } = await importEnv()
+
+  assert.equal(env.ENV_NAME, '')
+})
+
+test('env.ANALYZE falls back to "false" when ANALYZE is not set', async () => {
+  clearEnvKeys()
+
+  const { env } = await importEnv()
+
+  assert.equal(env.ANALYZE, 'false')
+})
+
+test('env.ANALYZE reads its value from ANALYZE', async () => {
+  clearEnvKeys()
+  process.env.ANALYZE = 'true'
+
+  const { env } = await importEnv()
+
+  assert.equal(env.ANALYZE, 'true')
+})
+
+test('env.ANALYZE ignores the legacy NEXT_PUBLIC_ANALYZE variable', async () => {
+  clearEnvKeys()
+  process.env.NEXT_PUBLIC_ANALYZE = 'true'
+
+  const { env } = await importEnv()
+
+  assert.equal(env.ANALYZE, 'false')
+})
+
+test('env exposes the expected shape when every variable is set at once', async () => {
+  clearEnvKeys()
+  process.env.NEXT_PUBLIC_MOCK = 'true'
+  process.env.NEXT_PUBLIC_ENV_NAME = 'local'
+  process.env.ANALYZE = 'true'
+
+  const { env } = await importEnv()
+
+  assert.deepEqual(env, {
+    VERSION: '',
+    MOCK: 'true',
+    ENV_NAME: 'local',
+    ANALYZE: 'true'
+  })
+})
+
+test('env exposes only the default values when no relevant variables are set', async () => {
+  clearEnvKeys()
+
+  const { env } = await importEnv()
+
+  assert.deepEqual(env, {
+    VERSION: '',
+    MOCK: 'false',
+    ENV_NAME: '',
+    ANALYZE: 'false'
+  })
+})


### PR DESCRIPTION
## Summary

CodeRabbit auto-generated #23 in response to a unit-test-generation request on #19. Its tests overlapped with the regression tests already added there, so this integrates rather than duplicates.

- **`src/config/env.test.ts`**: adopted as-is from #23. 11 `node:test` unit tests covering `env.ts`'s variable precedence/fallbacks — coverage this repo didn't have (only indirect e2e assertions of the rendered `/config` page). Added a `test:unit` script (`node --test src/**/*.test.ts`, using Node's built-in test runner + native TS support — no new test framework dependency) and a CI step, since #23 only added the test file with nothing wired up to run it.
- **`e2e/page/navigation.spec.ts`**: merged. Kept my existing "no double slashes across all links" + click-through tests, added CodeRabbit's more granular per-link href assertions, `zh-TW` non-default-locale coverage, and its fuller 3-test `aria-current` suite (which supersedes the single test I'd written).
- **`e2e/page/query.spec.ts`**: replaced my "stops paginating" test (mocked only page 2; page 1 hit the live API) with CodeRabbit's version (mocks both pages, fully deterministic) plus its loading/error-state and Load-More-append tests.

Rebased onto `main` after #19/#20/#21/#22 merged (originally stacked on #19's branch) — cherry-picked cleanly, `ci.yml`/`package.json` auto-merged with #21's typecheck/cache additions with no conflicts.

Once merged, please close #23 as superseded.

## Test plan

- [x] `pnpm test:unit` — 11/11 pass
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm build` all pass
- [x] 14/16 e2e specs pass locally against the pre-installed Chromium; the 2 failures are pre-existing live-API-dependent tests this sandbox's network policy blocks (unrelated to this change)
- [ ] Full CI run (this PR's GitHub Actions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale-aware navigation links, including correct `href` formatting and `aria-current` active-page behavior.
  * Strengthened Query Page pagination behavior, including intermediate loading feedback and correct handling when no further results exist.
* **Tests**
  * Expanded Playwright e2e coverage for navigation and Query Page pagination (including locale prefixes, accessibility states, and “Load More” flows).
  * Added environment configuration unit tests and a new `test:unit` script.
  * Updated CI to run unit tests between type checking and linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->