### PR TITLE
build: bump version to 1.13.0, automate GitHub Release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,16 @@ jobs:
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
+          persist-credentials: false
           ref: ${{ github.event.inputs.tag || github.ref_name }}
 
       - name: Verify tag matches package.json version
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
           EXPECTED="v$(node -p "require('./package.json').version")"
-          if [ "$TAG" != "$EXPECTED" ]; then
-            echo "::error::Tag $TAG does not match package.json version ($EXPECTED). Bump package.json or use the matching tag."
+          if [ "$RELEASE_TAG" != "$EXPECTED" ]; then
+            echo "::error::Tag $RELEASE_TAG does not match package.json version ($EXPECTED). Bump package.json or use the matching tag."
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (defaults to the pushed tag when triggered automatically)'
-        required: false
+        description: 'Tag to release (e.g. v1.13.0)'
+        required: true
       body:
         description: 'Custom release notes (Markdown). Leave blank to auto-generate from merged PRs using .github/release.yml'
         required: false
@@ -19,9 +19,21 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          EXPECTED="v$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$EXPECTED" ]; then
+            echo "::error::Tag $TAG does not match package.json version ($EXPECTED). Bump package.json or use the matching tag."
+            exit 1
+          fi
+
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           body: ${{ github.event.inputs.body }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (defaults to the pushed tag when triggered automatically)'
+        required: false
+      body:
+        description: 'Custom release notes (Markdown). Leave blank to auto-generate from merged PRs using .github/release.yml'
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          body: ${{ github.event.inputs.body }}
+          generate_release_notes: ${{ github.event.inputs.body == '' || github.event.inputs.body == null }}

--- a/e2e/page/config.spec.ts
+++ b/e2e/page/config.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test'
 
+import packageJson from '../../package.json'
+
 test.beforeEach(async ({ page }) => {
   await page.goto('http://localhost:3000/config')
 })
@@ -16,8 +18,14 @@ test.describe('Config Page', () => {
     // ENV_NAME and MOCK are injected via the webServer env in
     // playwright.config.ts. Before the env.ts fix these read the wrong
     // (unprefixed) process.env keys and always came back "" / "false".
-    await expect(page.getByTestId('env-json-values')).toHaveText(
-      '{ "VERSION": "1.12.0", "MOCK": "true", "ENV_NAME": "local", "ANALYZE": "false" }'
-    )
+    // VERSION is read from package.json instead of hardcoded so this
+    // doesn't break on every version bump.
+    const envText = await page.getByTestId('env-json-values').innerText()
+    expect(JSON.parse(envText)).toEqual({
+      VERSION: packageJson.version,
+      MOCK: 'true',
+      ENV_NAME: 'local',
+      ANALYZE: 'false'
+    })
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-app-boilerplate",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "private": true,
   "author": {
     "name": "POPO He",


### PR DESCRIPTION
## Summary

- `package.json`: `1.12.0` → `1.13.0`, following this repo's convention of a version bump PR per tag.
- Add `.github/workflows/release.yml`: `.github/release.yml` (the categorized changelog config) already existed but nothing ever triggered it, so every previous release's notes had to be written by hand. This workflow fires on any `v*` tag push and creates a GitHub Release via [`softprops/action-gh-release`](https://github.com/softprops/action-gh-release), auto-generating notes from merged PRs since the previous tag. It also supports `workflow_dispatch` with a custom `body` input for one-off releases that want hand-written notes instead of the auto-generated summary — will use that for `v1.13.0` given the pace of change this release covers.

## Test plan

- [x] `pnpm lint` and `pnpm build` pass; bundled version string now reads `1.13.0`
- [ ] Trigger the new workflow via `workflow_dispatch` after merge to verify it actually creates a release


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrCyK6YLGQgk9AH3rAMzBf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically creates GitHub Releases on `v*` tag pushes and supports manual release creation with a specified tag and optional release notes.
  * Validates the selected tag matches the current package version before publishing and can auto-generate release notes when no custom body is provided.
* **Chores**
  * Bumped package version from **1.12.0** to **1.13.0**.
* **Tests**
  * Updated end-to-end checks to verify the config page environment JSON using the current package version instead of a hardcoded value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->