### PR TITLE
perf: remove next-view-transitions, tune nav-link prefetch per destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Welcome to my all-in-one Next.js project with app router!
 - ⚡ [Next.js](https://nextjs.org) with App Router support
 - 🔥 Type checking [TypeScript](https://www.typescriptlang.org)
 - 💎 Integrate with [Tailwind CSS](https://tailwindcss.com)
-- 🖼️ Navigate animation with [next-view-transitions](https://github.com/shuding/next-view-transitions)
 - 🧰 Statem management with [Valtio](https://valtio.pmnd.rs/) and [React Query](https://tanstack.com/query/latest/)
 - ✅ Strict Mode for TypeScript and React 19
 - 📏 Linter with [ESLint](https://eslint.org) (Next.js Core Web Vitals, TypeScript, React)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "axios": "^1.18.1",
     "next": "16.2.10",
     "next-intl": "4.13.2",
-    "next-view-transitions": "^0.3.5",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "tailwindcss": "4.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       next-intl:
         specifier: 4.13.2
         version: 4.13.2(next@16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      next-view-transitions:
-        specifier: ^0.3.5
-        version: 0.3.5(next@16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -4454,16 +4451,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  next-view-transitions@0.3.5:
-    resolution:
-      {
-        integrity: sha512-yP8OPNydLmKpmE94hLurLGEzPsUy1uyl9iSv8oxaC2JwhSXTD86SVwk1NMMQT7Ado4kMENDJ7fNBIXHy3GU/Lg==
-      }
-    peerDependencies:
-      next: '>=14.0.0'
-      react: '>=18.2.0 || ^19.0.0'
-      react-dom: '>=18.2.0 || ^19.0.0'
 
   next@16.2.10:
     resolution:
@@ -8938,12 +8925,6 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@swc/helpers'
-
-  next-view-transitions@0.3.5(next@16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      next: 16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   next@16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,5 @@
 import { NextIntlClientProvider } from 'next-intl'
 import { getTranslations } from 'next-intl/server'
-import { ViewTransitions } from 'next-view-transitions'
 import { Inter } from 'next/font/google'
 import { ReactNode } from 'react'
 
@@ -43,17 +42,15 @@ export default async function LocaleLayout(props: Props) {
   const { children } = props
 
   return (
-    <ViewTransitions>
-      <html className="h-full" lang={locale}>
-        <body className={clsx(inter.className, 'flex h-full flex-col')}>
-          <NextIntlClientProvider>
-            <QueryProvider>
-              <Navigation />
-              {children}
-            </QueryProvider>
-          </NextIntlClientProvider>
-        </body>
-      </html>
-    </ViewTransitions>
+    <html className="h-full" lang={locale}>
+      <body className={clsx(inter.className, 'flex h-full flex-col')}>
+        <NextIntlClientProvider>
+          <QueryProvider>
+            <Navigation />
+            {children}
+          </QueryProvider>
+        </NextIntlClientProvider>
+      </body>
+    </html>
   )
 }

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -13,7 +13,13 @@ export default function Navigation() {
           <NavigationLink href="/">{t('home')}</NavigationLink>
           <NavigationLink href="/about">{t('about')}</NavigationLink>
           <NavigationLink href="/config">{t('config')}</NavigationLink>
-          <NavigationLink href="/query">{t('query')}</NavigationLink>
+          {/* /query is the one link with real async data (a live API fetch,
+              cached via ISR) — prefetching it means that content is usually
+              already loaded by the time it's clicked, unlike the other pages
+              which are trivial to fetch fresh anyway. */}
+          <NavigationLink prefetch href="/query">
+            {t('query')}
+          </NavigationLink>
         </div>
         <LocaleSwitcher />
       </nav>

--- a/src/components/navigationLink.tsx
+++ b/src/components/navigationLink.tsx
@@ -1,24 +1,34 @@
 'use client'
 
 import { useLocale } from 'next-intl'
-import { Link as TransitionLink } from 'next-view-transitions'
+import NextLink from 'next/link'
 import { ComponentProps } from 'react'
 
 import clsx from 'clsx'
 
 import { Link, usePathname } from '@/navigation'
 
-export default function NavigationLink({ href, ...rest }: ComponentProps<typeof Link>) {
+export default function NavigationLink({
+  href,
+  // Defaults to false: the persistent nav links remount on every
+  // locale switch, and Next.js re-fires each remounted Link's
+  // automatic prefetch several times over during that transition
+  // (measured: 17 requests for 4 links on a single locale switch).
+  // Links whose destination has real async work worth prefetching
+  // ahead of the click can opt back in explicitly (see Navigation.tsx).
+  prefetch = false,
+  ...rest
+}: ComponentProps<typeof Link>) {
   const pathname = usePathname()
   const locale = useLocale()
   const isActive = pathname === href
 
   return (
-    <TransitionLink
+    <NextLink
       {...rest}
       aria-current={isActive ? 'page' : undefined}
       href={href === '/' ? `/${locale}` : `/${locale}${href}`}
-      prefetch={false}
+      prefetch={prefetch}
       className={clsx(
         'inline-block px-2 py-3 transition-colors',
         isActive ? 'text-white' : 'text-gray-400 hover:text-gray-200'


### PR DESCRIPTION
## Summary
- Investigated a report of dropped FPS during navigation and a "waits for the API before switching" feeling on `/query`.
- **FPS**: confirmed with a controlled before/after test (same navigation, only the Link component swapped, all other code identical) that `next-view-transitions` is the cause — **60fps / 0 dropped frames** without it vs **~47-51fps with 8-10 frames worse than 30fps and gaps up to 83ms** with it. Removed the dependency and the `ViewTransitions` wrapper entirely.
- **`/query` feeling slow**: traced to the persistent nav links having `prefetch={false}` (from the previous PR's storm fix) — every click, even to a cheap static page, now paid a real (if small) network round trip with zero visual feedback. Tried adding a `query/loading.tsx` skeleton for a true streaming fallback, but discovered it **silently breaks static generation**: combined with `dynamic = 'force-static'`, Next.js 16.2.10 bakes in a 404 at build time with no error or warning — only caught by inspecting the raw `.next/server/app/.../query.meta` output. Not shipping that.
- Instead, refined the prefetch fix per-link: `NavigationLink` still defaults `prefetch` to `false` (avoids the locale-switch request storm — still measured at ~3 requests total on a locale switch, down from the original 17), but `/query`'s link now explicitly opts back in (`prefetch`) since it's the one destination with real async data worth loading ahead of the click.

## Test plan
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (100% coverage maintained)
- [x] `pnpm build` (production build, all routes still SSG/●, no accidental 404s baked in — verified via `.next/server/app/*/query.meta`)
- [x] Manual, real production server (`pnpm build && pnpm start`), Chrome DevTools Protocol frame-timing capture: 60fps/0 dropped frames after removing `next-view-transitions` (was ~47-51fps with dropped frames before)
- [x] Manual: locale-switch request count still ~3 (not the original 17), no 404s
- [x] Manual: nav clicks, `aria-current`, locale switch all still land on the correct URL/locale


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrCyK6YLGQgk9AH3rAMzBf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation links now use standard page navigation with optional prefetching.
  * The Query page can begin loading before it is opened, improving navigation responsiveness.

* **Bug Fixes**
  * Removed animated view transitions to provide more consistent navigation behavior.

* **Documentation**
  * Updated the feature list to reflect the current navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->